### PR TITLE
Added missing includes

### DIFF
--- a/UnrealDI/Source/UnrealDI/Public/DI/Factory.h
+++ b/UnrealDI/Source/UnrealDI/Public/DI/Factory.h
@@ -4,6 +4,7 @@
 
 #include "DI/Impl/IsUInterface.h"
 #include "DI/Impl/StaticClass.h"
+#include "UObject/ScriptInterface.h"
 
 namespace UnrealDI_Impl
 {

--- a/UnrealDI/Source/UnrealDI/Public/DI/Impl/Operations/ByInterfacesOperation.h
+++ b/UnrealDI/Source/UnrealDI/Public/DI/Impl/Operations/ByInterfacesOperation.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "UObject/Class.h"
 #include "Templates/UnrealTypeTraits.h"
 
 namespace UnrealDI_Impl

--- a/UnrealDI/Source/UnrealDI/Public/DI/Impl/Operations/FromBlueprintOperation.h
+++ b/UnrealDI/Source/UnrealDI/Public/DI/Impl/Operations/FromBlueprintOperation.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "UObject/Class.h"
+#include "Templates/SubclassOf.h"
 
 namespace UnrealDI_Impl
 {

--- a/UnrealDI/Source/UnrealDI/Public/DI/ObjectsCollection.h
+++ b/UnrealDI/Source/UnrealDI/Public/DI/ObjectsCollection.h
@@ -6,6 +6,7 @@
 #include "HAL/UnrealMemory.h"
 #include "DI/Impl/IsUInterface.h"
 #include "DI/Impl/StaticClass.h"
+#include "UObject/ScriptInterface.h"
 
 /*
  * Iterator for TObjectsCollection

--- a/UnrealDITests/Source/UnrealDITests/Private/DependencyInjection.spec.cpp
+++ b/UnrealDITests/Source/UnrealDITests/Private/DependencyInjection.spec.cpp
@@ -1,6 +1,7 @@
 // Copyright Andrei Sudarikov. All Rights Reserved.
 
 #include "Misc/AutomationTest.h"
+#include "Launch/Resources/Version.h"
 #include "Tests/AutomationCommon.h"
 
 #include "DI/ObjectContainerBuilder.h"

--- a/UnrealDITests/Source/UnrealDITests/Public/LatentCommands.h
+++ b/UnrealDITests/Source/UnrealDITests/Public/LatentCommands.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Engine/Engine.h"
 #include "Tests/AutomationCommon.h"
 
 class FRunGC : public IAutomationLatentCommand

--- a/UnrealDITests/Source/UnrealDITests/Public/MockClasses.h
+++ b/UnrealDITests/Source/UnrealDITests/Public/MockClasses.h
@@ -5,6 +5,7 @@
 #include "TestClasses.h"
 #include "DI/Factory.h"
 #include "DI/ObjectsCollection.h"
+#include "Launch/Resources/Version.h"
 #include "MockClasses.generated.h"
 
 /* Implements IReader interface */


### PR DESCRIPTION
The original errors were reproduced when plugins were enabled in the project, but wasn't used yet. Tests plugin compilation was causing errors.
Another way to reproduce it - disable PCHs completely. I believe the problem is that your module relies on the order of shared PCHs, and when that order changes it causes problems.