### PR TITLE
Add UE version defines for UBT plugin

### DIFF
--- a/UnrealDI/Source/UnrealDIUbt/TargetFrameworkDetect.props
+++ b/UnrealDI/Source/UnrealDIUbt/TargetFrameworkDetect.props
@@ -17,5 +17,8 @@
 
 		<TargetFramework Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(EngineVersion)', '5.5.0'))">net8.0</TargetFramework>
 		<TargetFramework Condition="$([MSBuild]::VersionLessThan('$(EngineVersion)', '5.5.0'))">net6.0</TargetFramework>
+
+        <DefineConstants Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(EngineVersion)', '5.5.0'))">$(DefineConstants);UE_5_5_OR_LATER</DefineConstants>
+        <DefineConstants Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(EngineVersion)', '5.6.0'))">$(DefineConstants);UE_5_6_OR_LATER</DefineConstants>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
UnrealEngine.csproj.props doesn't define the UE_5_5_OR_LATER constants. They are defined individually in *Rules.csproj.

Therefore, I added a define to TargetFrameworkDetect.props based on EngineVersion.

<img width="714" height="376" alt="image" src="https://github.com/user-attachments/assets/c526a240-3735-419d-8edc-abf39cc2266f" />

Without my edits, I would not have been able to build a ubt project on version ue5.6 in rider